### PR TITLE
Add sample scripts to enable automated sec fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# enable-security-alerts-sample
-This repository contains sample scripts for Node and Bash which can be used to enable security vulnerability alerts in all of the repositories in a given organization. 
+# Enable security alerts and automated security fixes sample
+This repository contains sample scripts for Node and Bash which can be used to enable security alerts and automated security fixes in all of the repositories in a given organization. 
 
-This project is a being provided as a sample only which illustrates how to [enable vulnerability alerts](https://developer.github.com/v3/repos/#enable-vulnerability-alerts) in all repositories in a given organization. 
+This project is a being provided as a sample only which illustrates how to [enable vulnerability alerts](https://developer.github.com/v3/repos/#enable-vulnerability-alerts) and [enable automated security fixes](https://developer.github.com/v3/repos/#enable-automated-security-fixes) in all repositories in a given organization.
 
 ## Node script
 
@@ -12,8 +12,14 @@ This project is a being provided as a sample only which illustrates how to [enab
 * [Generate a new personal access token](https://github.com/settings/tokens) with `repo` and `read:org` permissions
 * Update `config.json` and include your new personal access token in the `accessToken` value. 
 
-### Calling this script 
-* At the commandline, run `node index.js myorgname` where `myorgname` is your organization. This will enable security vulnerability alerts on all private repositories in your organization. 
+### Calling this script to enable security alerts
+* At the commandline, run `node enable-security-alerts-for-org.js myorgname` where `myorgname` is your organization. This will enable security alerts on all private repositories in your organization.
+
+### Calling this script to enable automated security fixes
+
+**You'll need to enable security alerts before you can enable automated security fixes**
+
+* At the commandline, run `node enable-automated-security-fixes-for-org.js myorgname` where `myorgname` is your organization. This will enable security alerts on all private repositories in your organization.
 
 ## Shell script
 
@@ -21,8 +27,14 @@ This project is a being provided as a sample only which illustrates how to [enab
 * Ensure that you have `bash` shell available on your system. If you're running Windows, additional setup may be required. [How to install Bash on Windows 10](https://www.windowscentral.com/how-install-bash-shell-command-line-windows-10)
 * [Generate a new personal access token](https://github.com/settings/tokens) with `repo` and `read:org` permissions
 
-### Calling this script
-* At the commandline, run `./shell_script/enable_vulnerability_alerts.sh myorgname accessToken` where `myorgname` is your organization, and `accessToken` is the personal access token you generated earlier. 
+### Calling this script to enable security alerts
+* At the commandline, run `./shell_script/enable_vulnerability_alerts_for_entire_org.sh myorgname accessToken` where `myorgname` is your organization, and `accessToken` is the personal access token you generated earlier. 
+
+### Calling this script to enable automated security fixes
+
+**You'll need to enable security alerts before you can enable automated security fixes**
+
+* At the commandline, run `./shell_script/enable_automated_security_fixes_for_entire_org.sh myorgname accessToken` where `myorgname` is your organization, and `accessToken` is the personal access token you generated earlier. 
 
 ### Contributing
 If you'd like to contribute to this sample with fixes, or support for other platforms, please follow the [contribution guidelines](CONTRIBUTING.md).

--- a/enable-automated-security-fixes-for-org.js
+++ b/enable-automated-security-fixes-for-org.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+const [, , ...args] = process.argv;
+var configFile = require("./config.json");
+
+const request = require("request");
+const options = {
+  headers: {
+    "User-Agent": "request",
+    Authorization: `Bearer ${configFile.accessToken}`,
+    Accept: "application/vnd.github.london-preview+json"
+  }
+};
+
+// Gets the list of repositories from the organization specified in the commandline arguments
+request.get(`https://api.github.com/orgs/${args}/repos`, options, processRepos);
+
+// Processes the response from the repositories call, and then calls the REST API to enable automated security fixes on every repository in that organization.
+function processRepos(error, response, body) {
+  if (error) console.error("/repos error:", error);
+  if (response && response.statusCode != 200) {
+    console.log(
+      "Getting repos failed with statusCode: ",
+      response && response.statusCode
+    );
+  }
+
+  repos = JSON.parse(body);
+  for (var i = 0; i < repos.length; i++) {
+    request.put(
+      `https://api.github.com/repos/${repos[i].owner.login}/${
+        repos[i].name
+      }/automated-security-fixes`,
+      options,
+      function(error, response, body) {
+        if (error) console.error("error:", error);
+        if (response && response.statusCode == 204) {
+          console.log(`Success for ${response.request.path}}`);
+        } else {
+          console.log(`Failed for ${response.request.path}`);
+        }
+      }
+    );
+  }
+}

--- a/shell_script/enable_automated_security_fixes_for_entire_org.sh
+++ b/shell_script/enable_automated_security_fixes_for_entire_org.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne "2" ]; then
+  echo "Usage: $0 <organization name> <personal access token>"
+  echo "Get a personal access token at: https://github.com/settings/tokens"
+  exit 1
+fi
+
+# make sure jq is installed to parse json response
+command -v jq >/dev/null 2>&1 || { echo >&2 "Error: This script requires the 'jq' utility but it's not installed."; exit 1; }
+
+org_name=$1
+api_key=$2
+
+repo_url="https://api.github.com/orgs/$org_name/repos"
+
+echo "Getting all repository IDs for org $org_name"
+repo_ids=($(curl -s -H "Authorization: bearer $api_key" $repo_url | jq ".[].id"))
+echo "Retrieved ${#repo_ids[@]} repo IDs for org $org_name"
+
+for repo_id in ${repo_ids[@]}; do
+  echo "Enabling automated security fixes for repository id: $repo_id"
+  enable_url="https://api.github.com/repositories/$repo_id/automated-security-fixes"
+  curl -s -X PUT -H "Authorization: bearer $api_key" -H "Accept: application/vnd.github.london-preview+json" $enable_url
+done


### PR DESCRIPTION
Adding node and bash scripts to enable automated security fixes for all
private repos for a given org.

@jhutchings1 thoughts on referring to both scripts in the readme?