### PR TITLE
Execute API calls in series to prevent hitting rate limit

### DIFF
--- a/enable-automated-security-fixes-for-org.js
+++ b/enable-automated-security-fixes-for-org.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 require('dotenv').config()
-
+const pReduce = require('./lib/p-reduce');
+const delay = require('./lib/delay');
 const Octokit = require('@octokit/rest')
 const octokit = new Octokit({
   auth: process.env.GH_AUTH_TOKEN,
@@ -14,32 +15,34 @@ const options = octokit.repos.listForOrg.endpoint.merge({org: owner, type: 'all'
 
 octokit
   .paginate(options)
-  .then(repositories => {
-    for (const repository of repositories) {
-      if (!repository.archived) {
-        const repo = repository.name
-
-        octokit.repos
-          .enableAutomatedSecurityFixes({
-            owner,
-            repo
-          })
-          .then(response => {
-            if (response && response.status === 204) {
-              console.log(`Success for ${owner}/${repo}`)
-            } else {
-              console.log(`Failed for ${owner}/${repo}`)
-            }
-          })
-          .catch(error => {
-            console.error(`Failed for ${owner}/${repo}
-  ${error.message}
-  ${error.documentation_url}
-`)
-          })
+  .then(repositories =>
+    pReduce(repositories, (repository) => {
+      if (repository.archived) {
+        return Promise.resolve();
       }
-    }
-  })
+      const repo = repository.name
+
+      return octokit.repos
+        .enableAutomatedSecurityFixes({
+          owner,
+          repo
+        })
+        .then(response => {
+          if (response && response.status === 204) {
+            console.log(`Success for ${owner}/${repo}`)
+          } else {
+            console.log(`Failed for ${owner}/${repo}`)
+          }
+          return delay(500);
+        })
+        .catch(error => {
+          console.error(`Failed for ${owner}/${repo}
+${error.message}
+${error.documentation_url}
+`)
+        })
+    })
+  )
   .catch(error => {
     console.error(`Getting repositories for organization ${owner} failed.
   ${error.message} (${error.status})

--- a/enable-security-alerts-for-org.js
+++ b/enable-security-alerts-for-org.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 require('dotenv').config()
-
+const pReduce = require('./lib/p-reduce');
+const delay = require('./lib/delay');
 const Octokit = require('@octokit/rest')
 const octokit = new Octokit({
   auth: process.env.GH_AUTH_TOKEN,
@@ -14,32 +15,34 @@ const options = octokit.repos.listForOrg.endpoint.merge({org: owner, type: 'all'
 
 octokit
   .paginate(options)
-  .then(repositories => {
-    for (const repository of repositories) {
-      if (!repository.archived) {
-        const repo = repository.name
-
-        octokit.repos
-          .enableVulnerabilityAlerts({
-            owner,
-            repo
-          })
-          .then(response => {
-            if (response && response.status === 204) {
-              console.log(`Success for ${owner}/${repo}`)
-            } else {
-              console.log(`Failed for ${owner}/${repo}`)
-            }
-          })
-          .catch(error => {
-            console.error(`Failed for ${owner}/${repo}
-  ${error.message}
-  ${error.documentation_url}
-`)
-          })
+  .then(repositories =>
+    pReduce(repositories, (repository) => {
+      if (repository.archived) {
+        return Promise.resolve();
       }
-    }
-  })
+      const repo = repository.name
+
+      return octokit.repos
+        .enableVulnerabilityAlerts({
+          owner,
+          repo
+        })
+        .then(response => {
+          if (response && response.status === 204) {
+            console.log(`Success for ${owner}/${repo}`)
+          } else {
+            console.log(`Failed for ${owner}/${repo}`)
+          }
+          return delay(500);
+        })
+        .catch(error => {
+          console.error(`Failed for ${owner}/${repo}
+${error.message}
+${error.documentation_url}
+`)
+        })
+    })
+  )
   .catch(error => {
     console.error(`Getting repositories for organization ${owner} failed.
   ${error.message} (${error.status})

--- a/lib/delay.js
+++ b/lib/delay.js
@@ -1,0 +1,3 @@
+const delay = timeout => new Promise(resolve => setTimeout(resolve, timeout));
+
+module.exports = delay;

--- a/lib/p-reduce.js
+++ b/lib/p-reduce.js
@@ -1,0 +1,7 @@
+const pReduce = (values, fn) =>
+  values.reduce(
+    (prev, ...args) => prev.then(() => fn(...args)),
+    Promise.resolve()
+  );
+
+module.exports = pReduce;


### PR DESCRIPTION
Fixes https://github.com/github/enable-security-alerts-sample/issues/9

In short, the issue is that once the list of repositories has been fetched from the API, all subsequent API calls are executed simultaneously in parallel.

I've refactored the code to the bare minimum to ensure that only one API call happens at a time (i.e. all in series), and introduced a 500ms delay between calls.

This allows us to execute this script within our organisation (having over 200 repositories) without ever hitting the API rate limits.

Naturally, if there are any changes required, please let me know (or make them directly here).