### PR TITLE
Shell script rate limiting

### DIFF
--- a/shell_script/enable_automated_security_fixes_for_entire_org.sh
+++ b/shell_script/enable_automated_security_fixes_for_entire_org.sh
@@ -27,8 +27,9 @@ do
 
   for repo_id in ${repo_ids[@]}; do
     echo "Enabling automated security fixes for repository id: $repo_id"
-  enable_url="https://api.github.com/repositories/$repo_id/automated-security-fixes"
-  curl -s -X PUT -H "Authorization: bearer $api_key" -H "Accept: application/vnd.github.london-preview+json" $enable_url  
+    enable_url="https://api.github.com/repositories/$repo_id/automated-security-fixes"
+    curl -s -X PUT -H "Authorization: bearer $api_key" -H "Accept: application/vnd.github.london-preview+json" $enable_url
+    sleep 1 #rate limiting to prevent blocking by github server
   done
   
   i=$((i+1))

--- a/shell_script/enable_vulnerability_alerts_for_entire_org.sh
+++ b/shell_script/enable_vulnerability_alerts_for_entire_org.sh
@@ -29,6 +29,7 @@ do
     echo "Enabling vulnerability alerts for repository id: $repo_id"
     enable_url="https://api.github.com/repositories/$repo_id/vulnerability-alerts"
     curl -s -X PUT -H "Authorization: bearer $api_key" -H "Accept: application/vnd.github.dorian-preview+json" $enable_url
+    sleep 1 #rate limiting to prevent blocking by github server
   done
   
   i=$((i+1))


### PR DESCRIPTION
Added basic rate limiting in the two shell scripts to prevent github server blocking requests when running the scripts against hundreds of corporate repo's.
Fix fo issue #12